### PR TITLE
Fixed package.json exporting for npm-css

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+// Blank export for parcelify

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Render elements consistently. Style with best practices.",
   "author": "Jonathan Neal",
   "license": "CC0",
-  "main": "dist/sanitize.css",
+  "style": "dist/sanitize.css",
   "homepage": "https://github.com/jonathantneal/sanitize.css",
   "repository": {
     "type": "git",
@@ -20,5 +20,9 @@
     "gulp-postcss": "^4.0.3",
     "gulp-sass": "^1.3.3",
     "gulp-sourcemaps": "^1.5.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "gulp"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "Render elements consistently. Style with best practices.",
   "author": "Jonathan Neal",
   "license": "CC0",
+  "main": "index.js",
   "style": "dist/sanitize.css",
+  "files": [
+    "dist",
+    "LICENSE.md",
+    "README.md",
+    "sanitize.scss"
+  ],
   "homepage": "https://github.com/jonathantneal/sanitize.css",
   "repository": {
     "type": "git",
@@ -22,7 +29,6 @@
     "gulp-sourcemaps": "^1.5.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "gulp"
+    "build": "gulp"
   }
 }


### PR DESCRIPTION
This should enable consumption via npm-css (and mostly likely parcelify).

Also added npm scripts so all that is required to build is:

``` sh
$ git clone https://github.com/jonathantneal/sanitize.css
$ cd sanitize.css
$ npm install
# Make modifications
$ npm start
# Newly built css file awaits
```

Come to think of it, you might not even need to publish a built css file and building it on demand using `postinstall` scripts.  see https://docs.npmjs.com/misc/scripts  I'm not sure what best practice is, as I'm new to modules that need build steps but I'll let you know once I know more.

Closes https://github.com/jonathantneal/sanitize.css/issues/1
