### PR TITLE
add npm & bower version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sanitize.css
 
+[![npm-image](https://img.shields.io/npm/v/sanitize.css.svg?style=flat-square)](https://www.npmjs.com/package/sanitize.css)
+![bower-image](https://img.shields.io/bower/v/sanitize.css.svg?style=flat-square)
+
 Render elements consistently. Style with best practices.
 
 


### PR DESCRIPTION
As suggested by @davidhund: https://github.com/jonathantneal/sanitize.css/issues/19#issuecomment-88032126

Adding these seems to indicate versions are out of sync between `bower` & `npm`. `bower` is up to 2.0.0, npm is at 1.1.0. See https://github.com/ngoldman/sanitize.css/tree/patch-1#readme for a preview and to see what I'm talking about.

Having these badges here would help keep things in sync! :grin:
