### PR TITLE
specify the body background color

### DIFF
--- a/sanitize.scss
+++ b/sanitize.scss
@@ -7,6 +7,7 @@ $root-font-size: 16px !default;
 $root-line-height: 1.5 !default;
 $root-text-rendering: optimizeLegibility !default;
 
+$body-background-color: #FFFFFF !default;
 $anchor-text-decoration: none !default;
 $form-element-background-color: transparent !default;
 $form-element-min-height: if(unitless($root-line-height), #{$root-line-height}em, if(unit($root-line-height) != '%', $root-line-height, null)) !default;
@@ -143,6 +144,12 @@ textarea {
 	cursor: $root-cursor;
 	font: #{$root-font-size}/#{$root-line-height} $root-font-family;
 	text-rendering: $root-text-rendering;
+}
+
+// specify the body background color
+
+body {
+	background-color: $body-background-color;
 }
 
 // specify the text decoration of anchors


### PR DESCRIPTION
Most of the developers assume (speaking from personal experiences) that the website background color is set white but it isn't. Its just browser default background, the website background is transparent.

The problem is when the site gets iframe'd because it inherits its background color and it can become illegible.

There's also another problem described in SMACSS book:

> I highly recommended that you specify a body background. Some
> users may define their own background as something other than
> white. If you work off the expectation that the background will be
> white, your design may look broken. Worse, your font colour choice
> may clash with the user’s setting and make your site unusable.
