### PR TITLE
some form elements doest not need min-height equals to line-height

### DIFF
--- a/sanitize.scss
+++ b/sanitize.scss
@@ -186,7 +186,22 @@ textarea {
 // specify the minimum height of form elements
 
 button,
-input,
+[type="button"],
+[type="date"],
+[type="datetime"],
+[type="datetime-local"],
+[type="email"],
+[type="month"],
+[type="number"],
+[type="password"],
+[type="reset"],
+[type="search"],
+[type="submit"],
+[type="tel"],
+[type="text"],
+[type="time"],
+[type="url"],
+[type="week"],
 select,
 textarea {
 	min-height: $form-element-min-height;


### PR DESCRIPTION
Some form elements like color, range, checkbox and radio does not need min-height equals to line-height.

Example with line-height (and min-height): 4:
http://i.imgur.com/yHDf9Cy.png

Example without min-height:
http://i.imgur.com/hEBTrje.png

Thanks!
