### PR TITLE
Changed foreground ::selection color variable.

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -244,7 +244,7 @@ textarea {
 
 ::selection {
 	background-color: var(--selection-background-color, #b3d4fc); /* required when declaring ::selection */
-	color: var(--selection-background-color, #4c2b03);
+	color: var(--selection-color, #4c2b03);
 	text-shadow: var(--selection-text-shadow, none);
 }
 


### PR DESCRIPTION
The same variable was being used for both the `color` and `background-color` rules for ::selection, which would result in unreadable selected text.
