### PR TITLE
Allow stylus variables to be overridden

### DIFF
--- a/sanitize.styl
+++ b/sanitize.styl
@@ -1,28 +1,28 @@
 /*! sanitize.css v3.0.0 | CC0 1.0 Public Domain | github.com/10up/sanitize.css */
 
-root-background-color = #FFFFFF
-root-box-sizing = border-box
-root-color = #000000
-root-cursor = default
-root-font-family = sans-serif
-root-font-size = 100%
-root-line-height = 1.5
-root-text-rendering = optimizeLegibility
+root-background-color ?= #FFFFFF
+root-box-sizing ?= border-box
+root-color ?= #000000
+root-cursor ?= default
+root-font-family ?= sans-serif
+root-font-size ?= 100%
+root-line-height ?= 1.5
+root-text-rendering ?= optimizeLegibility
 
-anchor-text-decoration = none
-background-repeat = no-repeat
-form-element-background-color = transparent
-form-element-min-height = 1.5em
-media-element-vertical-align = middle
-monospace-font-family = monospace
-nav-list-style = none
-selection-background-color = #B3D4FC
-selection-color = #ffffff
-selection-text-shadow = none
-small-font-size = 75%
-table-border-collapse = collapse
-table-border-spacing = 0
-textarea-resize = vertical
+anchor-text-decoration ?= none
+background-repeat ?= no-repeat
+form-element-background-color ?= transparent
+form-element-min-height ?= 1.5em
+media-element-vertical-align ?= middle
+monospace-font-family ?= monospace
+nav-list-style ?= none
+selection-background-color ?= #B3D4FC
+selection-color ?= #ffffff
+selection-text-shadow ?= none
+small-font-size ?= 75%
+table-border-collapse ?= collapse
+table-border-spacing ?= 0
+textarea-resize ?= vertical
 
 // Function form-element-min-height(root-line-height: int)
 form-element-min-height(root-line-height)


### PR DESCRIPTION
This is similar to `!default;` in scss

http://learnboost.github.io/stylus/docs/operators.html#conditional-assignment--
