### PR TITLE
Fix `form-element-min-height` function and typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import 'vendors/sanitize.scss';
 ```
 
 ```stylus
-// overwrite defaults in sanitize.scss
+// overwrite defaults in sanitize.styl
 root-font-family = "Open Sans", sans-serif
 root-text-rendering = optimizeSpeed
 

--- a/sanitize.styl
+++ b/sanitize.styl
@@ -27,7 +27,7 @@ textarea-resize ?= vertical
 // Function form-element-min-height(root-line-height: int)
 form-element-min-height(root-line-height)
 	if unit(root-line-height) == ''
-		{root-line-height}em
+		unit(root-line-height, em)
 	else if unit(root-line-height) != '%'
 		root-line-height
 	else


### PR DESCRIPTION
Stylus Interpolation couldn't compile unit string. Use `unit` built in function instead. And fix typo README.md.
