### PR TITLE
standardize variable names

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -126,12 +126,12 @@ textarea {
 /* specify the root styles of the document */
 
 :root {
-	background-color: var(--html-background-color, #ffffff);
-	box-sizing: var(--html-box-sizing, border-box);
-	color: var(--html-color, #000000);
-	cursor: var(--html-cursor, default);
-	font: var(--html-font-size, 100%)/var(--html-line-height, 1.5) var(--font-family, sans-serif);
-	text-rendering: var(--html-text-rendering, optimizeLegibility);
+	background-color: var(--root-background-color, #ffffff);
+	box-sizing: var(--root-box-sizing, border-box);
+	color: var(--root-color, #000000);
+	cursor: var(--root-cursor, default);
+	font: var(--root-font-size, 100%)/var(--root-line-height, 1.5) var(--root-font-family, sans-serif);
+	text-rendering: var(--root-text-rendering, optimizeLegibility);
 }
 
 /* specify the text decoration of anchors */


### PR DESCRIPTION
Replace --html by --root and prefix --font-family with --root in sanitize.css to match preprocessors variable names.
