### PR TITLE
File References

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import url("vendors/sanitize.css");
 $root-font-family: "Open Sans", sans-serif
 $root-color: #333333
 
-import "vendors/sanitize.scss"
+import "vendors/sanitize.sass"
 ```
 
 ```scss


### PR DESCRIPTION
This is a simple fix that changes the extension for the Sass file references in the Readme file.
