### PR TITLE
Only apply h1 styling within `section` & `article`

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -112,7 +112,8 @@ body {
  * `section` and `article` contexts in Chrome, Firefox, and Safari.
  */
 
-h1 {
+section h1,
+article h1 {
 	font-size: 2em;
 	margin: .67em 0;
 }


### PR DESCRIPTION
I'm not sure about the purpose of the styling here to begin with; the comment doesn't offer much of an explanation. But in any case, it sounds like the intention is for the styling to only be applied within `article` and `section`, and not globally.
