### PR TITLE
alter main item of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sanitize.css",
   "version": "4.1.0",
   "description": "The best-practices alternative to CSS resets.",
-  "main": "index.js",
+  "main": "sanitize.css",
   "style": "sanitize.css",
   "devDependencies": {
     "postcss": "^5.0.21",


### PR DESCRIPTION
I'm newbie developer, so if I make any mistakes or do something rude to you I'm so sorry.

Today I was developing with webpack with css-loader. 
I used to use Normalize.css. And when we were using it, we can write like below.

``` css
@import 'normalize.css'
```

(we use it by npm)

And we decided to switch to sanitise.css. (Thanks for awesome tool!!)
But we can't write like below... this produces error when webpack loads CSS.

``` css
@import 'sanitise.css'
```

And I tried in several ways and found the answer.

``` css
@import 'sanitise.css/sanitise.css'
```

I guess this is because the wrong designation of 'main' of package.json. That's why I made this pull req.

Thanks
