### PR TITLE
Set main to be sanitize.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sanitize.css",
   "version": "4.1.0",
   "description": "The best-practices alternative to CSS resets.",
-  "main": "index.js",
+  "main": "sanitize.css",
   "style": "sanitize.css",
   "devDependencies": {
     "postcss": "^5.0.21",


### PR DESCRIPTION
Setting "main" correctly will allow the path to the css file to be resolved. e.g. when using webpack css loader it will be possible to `@import "~sanitize.css";`
