### PR TITLE
Allow form elements to inherit line-height from html

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ button, input, select, textarea {
 	border-style: none;
 	color: inherit;
 	font-size: 1em;
+	line-height: inherit;
+	margin: 0;
 }
 ```
 

--- a/sanitize.css
+++ b/sanitize.css
@@ -344,6 +344,7 @@ textarea {
 	border-style: none; /* 1 */
 	color: inherit; /* 1 */
 	font-size: 1em; /* 1 */
+	line-height: inherit; /* 1 */
 	margin: 0; /* 2 */
 }
 


### PR DESCRIPTION
Override browser default `line-height: normal;` to `line-height: inherit;`

Resolves #118.