### PR TITLE
Append remove outline from select box in Firefox

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -398,6 +398,15 @@ html [type="button"], /* 1 */
 }
 
 /**
+ * Remove outline from select box in Firefox
+ */
+
+select:-moz-focusring {
+	color: transparent;
+	text-shadow: 0 0 0 #000000;
+}
+
+/**
  * Correct the border, margin, and padding in all browsers.
  */
 


### PR DESCRIPTION
Hello.

I got Firefox difference like this page.
http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002 

and append this answer's style
http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002