### PR TITLE
Reset the cursor to default for a disabled element

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -584,6 +584,7 @@ textarea,
  * inoperable elements (opinionated).
  */
 
-[aria-disabled] {
+[aria-disabled],
+[disabled] {
 	cursor: default;
 }


### PR DESCRIPTION
Pretty straightforward - restore the cursor to default for an element with the `disabled` attribute. This may advance the "opinionatedness" slightly. Let me know what you think!