### PR TITLE
add ~ to CSS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ see https://cdnjs.com/libraries/10up-sanitize.css
 in CSS (or LESS/SCSS/Stylus)
 
 ```css
-@import 'sanitize.css';
+@import '~sanitize.css';
 ```
 
 or in javascript:


### PR DESCRIPTION
Without the tilde, webpack will not know to look in `node_modules`, and instead will look for a file relative to the Sass file.
`@import "~sanitize.css/sanitize.css";` works as well