### PR TITLE
Uniform fixed-width fonts usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ code, kbd, pre, samp {
     /* Windows 6+ */ Consolas,
     /* Android 4+ */ Roboto Mono,
     /* Ubuntu 10.10+ */ Ubuntu Monospace,
+    /* KDE Plasma 5+ */ Noto Mono,
     /* KDE Plasma 4+ */ Oxygen Mono,
     /* Linux/OpenOffice fallback */ Liberation Mono,
     /* fallback */ monospace;

--- a/sanitize.css
+++ b/sanitize.css
@@ -124,6 +124,7 @@ pre {
     /* Android 4+ */ Roboto Mono,
     /* Ubuntu 10.10+ */ Ubuntu Monospace,
     /* KDE Plasma 5+ */ Noto Mono,
+    /* KDE Plasma 4+ */ Oxygen Mono,
     /* Linux/OpenOffice fallback */ Liberation Mono,
     /* fallback */ monospace; /* 1 */
 
@@ -173,6 +174,7 @@ samp {
     /* Windows 6+ */ Consolas,
     /* Android 4+ */ Roboto Mono,
     /* Ubuntu 10.10+ */ Ubuntu Monospace,
+    /* KDE Plasma 5+ */ Noto Mono,
     /* KDE Plasma 4+ */ Oxygen Mono,
     /* Linux/OpenOffice fallback */ Liberation Mono,
     /* fallback */ monospace; /* 1 */


### PR DESCRIPTION
Merged the fonts declaration of the pre and code,kbd,samp blocks to
use the same fallbacks.

The pre declaration hasn't be updated to use the new Noto Mono font and the code, kbd, samp block where missing the old KDE Plasma font for fallback.