### PR TITLE
Removed tap-highlight-color from mobile Safari

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -33,7 +33,8 @@
  * 4. Use a 4-space tab width in all browsers (opinionated).
  * 5. Prevent adjustments of font size after orientation changes in
  *    IE on Windows Phone and in iOS.
- * 6. Breaks words to prevent overflow in all browsers (opinionated).
+ * 6. Remove highlight when tapping links in mobile Safari
+ * 7. Breaks words to prevent overflow in all browsers (opinionated).
  */
 
 html {
@@ -57,7 +58,8 @@ html {
   tab-size: 4; /* 4 */
   -ms-text-size-adjust: 100%; /* 5 */
   -webkit-text-size-adjust: 100%; /* 5 */
-  word-break: break-word; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 6 */
+  word-break: break-word; /* 7 */
 }
 
 /* Sections


### PR DESCRIPTION
Webkit uses this tap color to highlight tapped form elements, links, and elements with various js events.
http://prntscr.com/mbxqwx
So, this rule removes this highlight.