### PR TITLE
Replace deprecated word-break by overflow-wrap

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -40,7 +40,7 @@ html {
   -webkit-tap-highlight-color: transparent /* 4 */;
   -ms-text-size-adjust: 100%; /* 5 */
   -webkit-text-size-adjust: 100%; /* 5 */
-  word-break: break-word; /* 6 */
+  overflow-wrap: break-word; /* 6 */
 }
 
 /* Sections


### PR DESCRIPTION
word-break is deprecated, overflow-wrap is the correct method to break words.