### PR TITLE
Fix reduce motion sub heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A separate stylesheet that normalizes typography using system interface fonts.
 
 #### Reduce Motion CSS
 
-A separate stylesheet that normalizes typography using system interface fonts.
+A separate stylesheet for restricting motion when the user has requested this at system level.
 
 ```html
 <link href="https://unpkg.com/sanitize.css/reduce-motion.css" rel="stylesheet" />


### PR DESCRIPTION
The text was the same as in _Typography_ section above. Probably someone just forgot to update the paragraph text.