### PR TITLE
table border-color currentColor

### DIFF
--- a/evergreen.css
+++ b/evergreen.css
@@ -189,13 +189,13 @@
 
 /**
  * 1. Collapse border spacing in all browsers (opinionated).
- * 2. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 2. Correct table border color in Chrome, Edge, and Safari.
  * 3. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 :where(table) {
   border-collapse: collapse; /* 1 */
-  border-color: inherit; /* 2 */
+  border-color: currentColor; /* 2 */
   text-indent: 0; /* 3 */
 }
 

--- a/sanitize.css
+++ b/sanitize.css
@@ -189,13 +189,13 @@
 
 /**
  * 1. Collapse border spacing in all browsers (opinionated).
- * 2. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 2. Correct table border color in Chrome, Edge, and Safari.
  * 3. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 :where(table) {
   border-collapse: collapse; /* 1 */
-  border-color: inherit; /* 2 */
+  border-color: currentColor; /* 2 */
   text-indent: 0; /* 3 */
 }
 


### PR DESCRIPTION
I could not find any source that border-color should be inherited.
Firefox, which is not listed as affected, uses "currentColor" and not "inherit".