### PR TITLE
Reset select appearance in Safari

### DIFF
--- a/forms.css
+++ b/forms.css
@@ -17,6 +17,7 @@
  */
 
 :where(select) {
+  -webkit-appearance: none;
   appearance: none;
   background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E") no-repeat right center / 1em;
   border-radius: 0;

--- a/forms.evergreen.css
+++ b/forms.evergreen.css
@@ -17,6 +17,7 @@
  */
 
 :where(select) {
+  -webkit-appearance: none;
   appearance: none;
   background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E") no-repeat right center / 1em;
   border-radius: 0;


### PR DESCRIPTION
The `appearance` property without vendor prefix will not work in Safari, so now the `select` style will not be rendered correctly.

Chrome:

<img width="69" alt="" src="https://user-images.githubusercontent.com/11547305/119268028-f8e05880-bc2b-11eb-9f09-c03749f4a76a.png">

Safari:

<img width="75" alt="" src="https://user-images.githubusercontent.com/11547305/119267930-9a1adf00-bc2b-11eb-8bf3-5872a3e37b42.png">
