### PR TITLE
Remove the `padding` on `td` and `th` in Firefox

### DIFF
--- a/evergreen.css
+++ b/evergreen.css
@@ -199,6 +199,14 @@
   text-indent: 0; /* 3 */
 }
 
+/**
+ * Remove the padding on table cells in Firefox.
+ */
+
+:where(td, th) {
+  padding: 0;
+}
+
 /* Forms
  * ========================================================================== */
 

--- a/sanitize.css
+++ b/sanitize.css
@@ -199,6 +199,14 @@
   text-indent: 0; /* 3 */
 }
 
+/**
+ * Remove the padding on table cells in Firefox.
+ */
+
+:where(td, th) {
+  padding: 0;
+}
+
 /* Forms
  * ========================================================================== */
 


### PR DESCRIPTION
Only in Firefox, `padding: 1px` is applied to `td` and `th`:

- https://searchfox.org/mozilla-central/source/layout/style/res/html.css#475

And it’s not applied in other browsers:

- https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/html/resources/html.css#318
- https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css#L264