### PR TITLE
Add `text-size-adjust`

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -41,6 +41,7 @@
   tab-size: 4; /* 4 */
   -webkit-tap-highlight-color: transparent; /* 5 */
   -webkit-text-size-adjust: 100%; /* 6 */
+  text-size-adjust: 100%; /* 6 */
 }
 
 /* Sections


### PR DESCRIPTION
`-webkit-text-size-adjust` is not supported by Chrome Android. Add `text-size-adjust` to support Chrome Android 54+. This defect results in a [webhint](https://webhint.io/) fault, which is a common CI gate.