### PR TITLE
1px td-padding also in Chromium and Safari

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -196,14 +196,6 @@
   text-indent: 0; /* 3 */
 }
 
-/**
- * Remove the padding on table cells in Firefox.
- */
-
-:where(td, th) {
-  padding: 0;
-}
-
 /* Forms
  * ========================================================================== */
 


### PR DESCRIPTION
It is not included in the user agent stylesheet

![grafik](https://user-images.githubusercontent.com/16326/133346475-4f328d66-8088-41d7-8b9c-78995184a873.png)

But somehow magically added.

Chrome:
![grafik](https://user-images.githubusercontent.com/16326/133346505-5b12e17a-ec95-4343-8919-d2b8dfcbd91e.png)

Safari:
![grafik](https://user-images.githubusercontent.com/16326/133346539-6b713b2f-28fb-4a17-adfa-a6db1be8792f.png)

Also in the spec:
https://www.w3.org/TR/css-tables-3/#mapping