### PR TITLE
Prevent zero-width space from consuming space in Safari.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to sanitize.css
 
+### 13.0.1 (September 28, 2021)
+
+- Fixed: Prevent zero-width space from consuming space in Safari.
+
 ### 13.0.0 (September 14, 2021)
 
 - Added: `:where` too all selectors, reducing specificity to nearly zero.

--- a/sanitize.css
+++ b/sanitize.css
@@ -101,7 +101,7 @@
 
 :where(nav li)::before {
   content: "\200B";
-  float: left;
+  postion: absolute;
 }
 
 /**

--- a/sanitize.css
+++ b/sanitize.css
@@ -101,7 +101,7 @@
 
 :where(nav li)::before {
   content: "\200B";
-  postion: absolute;
+  position: absolute;
 }
 
 /**


### PR DESCRIPTION
Fixes Safari display issue caused by commit https://github.com/csstools/sanitize.css/commit/97537649c8e5d53d98c8e4a6234a0917f824acf2. 

Linked to issue https://github.com/csstools/sanitize.css/issues/226 