### PR TITLE
Added `embed` and `object` elements in the `vertical-align` selector

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -161,7 +161,7 @@
  * Change the alignment on media elements in all browsers (opinionated).
  */
 
-:where(audio, canvas, iframe, img, svg, video) {
+:where(img, svg, video, audio, canvas, iframe, embed, object) {
   vertical-align: middle;
 }
 


### PR DESCRIPTION
- Added elements in the `vertical-align: middle;` selector
- Reorder elements so the more common elements are first for understandability / readability

Similarly as https://github.com/csstools/sanitize.css/pull/205, although they are seldom used, I believe these 2 extra elements should share the same `vertical-align: middle` as the others.

