### PR TITLE
fix(#233): made voiceover fix smaller

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -101,6 +101,7 @@
 
 :where(nav li)::before {
   content: "\200B";
+  height: 1px;
   float: left;
 }
 


### PR DESCRIPTION
Fixes #233 without breaking voiceover

A fix mostly inspired by https://github.com/twbs/bootstrap/blob/1df098361cac04217d6a464c80e890c4335ecb5c/scss/mixins/_visually-hidden.scss