### PR TITLE
Ensure that clicks on buttons with SVGs or other elements always register on the button rather than its children

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -216,6 +216,14 @@
 }
 
 /**
+ * Ensure that clicks on buttons with SVGs or other elements always register on the button itself and not its children.
+ */
+
+:where(button *, [type="button" i] *, [type="reset" i] *, [type="submit" i] *) {
+  pointer-events: none;
+}
+
+/**
  * Change the inconsistent appearance in all browsers (opinionated).
  */
 


### PR DESCRIPTION
This is something I've started doing in my own projects. It helps to clear up confusion between `target` and `currentTarget` since it's not always clear what a framework, for instance, may be using during event delegation.

This is a real-world example of an issue that is smoothed over with this fix: https://github.com/solidjs/solid-start/pull/636