### PR TITLE
feat(reduce-motion): remove view-transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ user has requested this at a system level.
 
 ### Reduce Motion Features
 
-##### Animations, scrolling effects, and transitions are reduced in all browsers
+##### Animations, scrolling effects, transitions and view transitions are reduced in all browsers
 
 ```css
 @media (prefers-reduced-motion: reduce) {
@@ -449,6 +449,10 @@ user has requested this at a system level.
     scroll-behavior: auto !important;
     transition-delay: 0s !important;
     transition-duration: 0s !important;
+  }
+
+  @view-transition {
+    navigation: none !important;
   }
 }
 ```

--- a/reduce-motion.css
+++ b/reduce-motion.css
@@ -3,6 +3,7 @@
  * 2. Remove fixed background attachments when motion is reduced (opinionated).
  * 3. Remove timed scrolling behaviors when motion is reduced (opinionated).
  * 4. Remove transitions when motion is reduced (opinionated).
+ * 5. Remove view-transitions when motion is reduced (opinionated).
  */
 
 @media (prefers-reduced-motion: reduce) {
@@ -16,5 +17,9 @@
     scroll-behavior: auto !important; /* 3 */
     transition-delay: 0s !important; /* 4 */
     transition-duration: 0s !important; /* 4 */
+  }
+
+  @view-transition {
+    navigation: none !important; /* 5 */
   }
 }


### PR DESCRIPTION
The new [@view-transition](https://developer.mozilla.org/en-US/docs/Web/CSS/@view-transition) API is [supported by](https://caniuse.com/mdn-css_at-rules_view-transition) most mayor browsers and allows for page transition animations. Disabled these on prefers-reduced-motion.