### PR TITLE
allow cursor on elements with disabled="false" attribute

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -337,7 +337,7 @@
  * inoperable elements in all browsers (opinionated).
  */
 
-:where([aria-disabled="true" i], [disabled]) {
+:where([aria-disabled="true" i], [disabled]):not([disabled="false"]) {
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
React components normally pass element properties via attributes, I suggest to make elements with disabled attribute with false value an exception and exclude it for the style cursor: not-allowed;