### PR TITLE
Remove the rule that resets margin-block for all nested lists

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -71,14 +71,6 @@
  * ========================================================================== */
 
 /**
- * Remove the margin on nested lists in Chrome, Edge, and Safari.
- */
-
-:where(dl, ol, ul) :where(dl, ol, ul) {
-  margin: 0;
-}
-
-/**
  * Add the correct box sizing in Firefox.
  */
 


### PR DESCRIPTION
Fixes #243.