### PR TITLE
Remove `border-color` override for tables

### DIFF
--- a/sanitize.css
+++ b/sanitize.css
@@ -186,14 +186,12 @@
 
 /**
  * 1. Collapse border spacing in all browsers (opinionated).
- * 2. Correct table border color in Chrome, Edge, and Safari.
- * 3. Remove text indentation from table contents in Chrome, Edge, and Safari.
+ * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 :where(table) {
   border-collapse: collapse; /* 1 */
-  border-color: currentColor; /* 2 */
-  text-indent: 0; /* 3 */
+  text-indent: 0; /* 2 */
 }
 
 /* Forms


### PR DESCRIPTION
Hello,

It appears that both Chrome and Safari now use `currentColor` as the default border colour for tables in line with the specs:

* https://developer.chrome.com/release-notes/149#remove_explicit_border_color_ua_stylesheet_rule_for_tables
* https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#Resolved-Issues (second "Resolved issue" section)

As a result, the reset for `border-color` on tables could be removed once Safari 27 and Chrome 151 are released following the project’s “minus two releases” policy.

Here is a test page: https://play.tailwindcss.com/SghL1ku13p

Cheers